### PR TITLE
fix: assertQueue now return queue-object like original amqplib

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -91,7 +91,11 @@ const createChannel = async () => ({
   },
   close: () => {},
   assertQueue: async queueName => {
+    if (!queueName) {
+      queueName = generateRandomQueueName();
+    }
     queues[queueName] = createQueue();
+    return { queue: queueName };
   },
   assertExchange: async (exchangeName, type) => {
     let exchange;
@@ -161,6 +165,15 @@ const createChannel = async () => ({
   }),
   purgeQueue: queueName => queues[queueName].purge()
 });
+
+const generateRandomQueueName = () => {
+  const ABS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let res = 'amq.gen-';
+  for(let i=0; i<22; i++){
+    res += ABS.charCodeAt(Math.floor(Math.random() * ABS.length));
+  }
+  return res;
+};
 
 module.exports = {
   connect: async () => ({

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -181,3 +181,23 @@ it('should not put nack-ed messages back to queue if requeue is set to false', a
 
   expect(reRead).toEqual(false);
 });
+
+test('assert queue should return object with property "queue"', async () => {
+  const connection = await amqp.connect('some-random-uri');
+  const channel = await connection.createChannel();
+  const queue = await channel.assertQueue('test-queue');
+  expect(queue).toMatchObject({
+    queue: 'test-queue'
+  });
+});
+
+test('assert empty queue should create new queue with random name with prefix "amq.gen-"', async () => {
+  const connection = await amqp.connect('some-random-uri');
+  const channel = await connection.createChannel();
+  const queue1 = await channel.assertQueue('');
+  const queue2 = await channel.assertQueue('');
+
+  expect(queue1.queue).toMatch(/^amq.gen-\w+/);
+  expect(queue2.queue).toMatch(/^amq.gen-\w+/);
+  expect(queue1.queue).not.toBe(queue2.queue);
+});


### PR DESCRIPTION
I little fix `assertQueue` method: now it returns queue-object like in original `amqplib`: 

```js
const queue = await channel.assertQueue('test-queue');
expect(queue).toMatchObject({
  queue: 'test-queue'
});
```

Also, I append possible create random queues like in original `amqplib` (e.g. `amq.gen-TjKUCjyd8Li7xUKGo5v9pg`): 

```js
const queue1 = await channel.assertQueue('');
const queue2 = await channel.assertQueue('');

expect(queue1.queue).toMatch(/^amq.gen-\w+/);
expect(queue2.queue).toMatch(/^amq.gen-\w+/);
expect(queue1.queue).not.toBe(queue2.queue);
```