### PR TITLE
feat: "credentials" added #16

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -176,10 +176,30 @@ const generateRandomQueueName = () => {
   return res;
 };
 
+const credentials = {
+  plain: (username, password) => ({
+    mechanism: 'PLAIN',
+    response: () => '',
+    username,
+    password
+  }),
+  amqplain: (username, password) => ({
+    mechanism: 'AMQPLAIN',
+    response: () => '',
+    username,
+    password
+  }),
+  external: () => ({
+    mechanism: 'EXTERNAL',
+    response: () => '',
+  })
+}
+
 module.exports = {
   connect: async () => ({
     createChannel,
     on: () => {},
     close: () => {}
-  })
+  }),
+  credentials
 };

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -243,3 +243,31 @@ test('assert empty queue should create new queue with random name with prefix "a
   expect(queue2.queue).toMatch(/^amq.gen-\w{22}/);
   expect(queue1.queue).not.toBe(queue2.queue);
 });
+
+test('assert "credentials" to have been defined with required methods', () => {
+  expect(amqp.credentials).toBeDefined();
+  expect(amqp.credentials.plain).toBeDefined();
+  expect(amqp.credentials.amqplain).toBeDefined();
+  expect(amqp.credentials.external).toBeDefined();
+});
+
+test('assert required methods of "credentials"', () => {
+  expect(amqp.credentials.plain('user', 'pass')).toEqual({
+    mechanism: 'PLAIN',
+    response: expect.any(Function),
+    username: 'user',
+    password: 'pass',
+  });
+
+  expect(amqp.credentials.amqplain('user', 'pass')).toEqual({
+    mechanism: 'AMQPLAIN',
+    response: expect.any(Function),
+    username: 'user',
+    password: 'pass',
+  });
+
+  expect(amqp.credentials.external()).toEqual({
+    mechanism: 'EXTERNAL',
+    response: expect.any(Function)
+  });
+});


### PR DESCRIPTION
Added functionality for credentials which is exposed in the original library
https://github.com/amqp-node/amqplib/blob/main/channel_api.js#L15

- [x] Functionality
- [x] Tests