### PR TITLE
Fix assertQueue Bug

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ const createQueue = () => {
   let subscriber = null;
 
   return {
-    add: item => {
+    add: (item) => {
       if (subscriber) {
         subscriber(item);
       } else {
@@ -15,14 +15,14 @@ const createQueue = () => {
       }
     },
     get: () => messages.shift() || false,
-    addConsumer: consumer => {
-      messages.forEach(item => consumer(item));
+    addConsumer: (consumer) => {
+      messages.forEach((item) => consumer(item));
       messages = [];
       subscriber = consumer;
     },
     stopConsume: () => (subscriber = null),
     getMessageCount: () => messages.length,
-    purge: () => (messages = [])
+    purge: () => (messages = []),
   };
 };
 
@@ -33,12 +33,12 @@ const createFanoutExchange = () => {
       bindings.push({
         targetQueue: queueName,
         options,
-        pattern
+        pattern,
       });
     },
     getTargetQueues: (routingKey, options = {}) => {
-      return [...bindings.map(binding => binding.targetQueue)];
-    }
+      return [...bindings.map((binding) => binding.targetQueue)];
+    },
   };
 };
 
@@ -49,13 +49,15 @@ const createDirectExchange = () => {
       bindings.push({
         targetQueue: queueName,
         options,
-        pattern
+        pattern,
       });
     },
     getTargetQueues: (routingKey, options = {}) => {
-      const matchingBinding = bindings.find(binding => binding.pattern === routingKey);
+      const matchingBinding = bindings.find(
+        (binding) => binding.pattern === routingKey
+      );
       return [matchingBinding.targetQueue];
-    }
+    },
   };
 };
 
@@ -66,15 +68,19 @@ const createHeadersExchange = () => {
       bindings.push({
         targetQueue: queueName,
         options,
-        pattern
+        pattern,
       });
     },
     getTargetQueues: (routingKey, options = {}) => {
       const isMatching = (binding, headers) =>
-        Object.keys(binding.options).every(key => binding.options[key] === headers[key]);
-      const matchingBinding = bindings.find(binding => isMatching(binding, options.headers || {}));
+        Object.keys(binding.options).every(
+          (key) => binding.options[key] === headers[key]
+        );
+      const matchingBinding = bindings.find((binding) =>
+        isMatching(binding, options.headers || {})
+      );
       return [matchingBinding.targetQueue];
-    }
+    },
   };
 };
 
@@ -82,33 +88,35 @@ const createChannel = async () => ({
   on: (eventName, listener) => {
     eventListeners.push({ eventName, listener });
   },
-  emit: emittedEventName => {
+  emit: (emittedEventName) => {
     eventListeners.forEach(({ eventName, listener }) => {
       if (eventName === emittedEventName) {
         listener();
       }
-    })
+    });
   },
   close: () => {},
-  assertQueue: async queueName => {
+  assertQueue: async (queueName) => {
     if (!queueName) {
       queueName = generateRandomQueueName();
     }
-    queues[queueName] = createQueue();
+    if (!(queueName in queues)) {
+      queues[queueName] = createQueue();
+    }
     return { queue: queueName };
   },
   assertExchange: async (exchangeName, type) => {
     let exchange;
 
-    switch(type) {
-      case 'fanout':
+    switch (type) {
+      case "fanout":
         exchange = createFanoutExchange();
         break;
-      case 'direct':
-      case 'x-delayed-message':
+      case "direct":
+      case "x-delayed-message":
         exchange = createDirectExchange();
         break;
-      case 'headers':
+      case "headers":
         exchange = createHeadersExchange();
         break;
     }
@@ -126,12 +134,12 @@ const createChannel = async () => ({
       content,
       fields: {
         exchange: exchangeName,
-        routingKey
+        routingKey,
       },
-      properties: options
+      properties: options,
     };
 
-    for(const queueName of queueNames) {
+    for (const queueName of queueNames) {
       queues[queueName].add(message);
     }
   },
@@ -139,10 +147,10 @@ const createChannel = async () => ({
     queues[queueName].add({
       content,
       fields: {
-        exchange: '',
-        routingKey: queueName
+        exchange: "",
+        routingKey: queueName,
       },
-      properties: { headers: headers || {} }
+      properties: { headers: headers || {} },
     });
   },
   get: async (queueName, { noAck } = {}) => {
@@ -153,53 +161,53 @@ const createChannel = async () => ({
     queues[queueName].addConsumer(consumer);
     return { consumerTag: queueName };
   },
-  cancel: async consumerTag => queues[consumerTag].stopConsume(),
+  cancel: async (consumerTag) => queues[consumerTag].stopConsume(),
   ack: async () => {},
   nack: async (message, allUpTo = false, requeue = true) => {
     if (requeue) {
       queues[message.fields.routingKey].add(message);
     }
   },
-  checkQueue: queueName => ({
+  checkQueue: (queueName) => ({
     queue: queueName,
-    messageCount: queues[queueName].getMessageCount()
+    messageCount: queues[queueName].getMessageCount(),
   }),
-  purgeQueue: queueName => queues[queueName].purge()
+  purgeQueue: (queueName) => queues[queueName].purge(),
 });
 
 const generateRandomQueueName = () => {
-  const ABC = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_';
-  let res = 'amq.gen-';
-  for( let i=0; i<22; i++ ){
-    res += ABC[(Math.floor(Math.random() * ABC.length))];
+  const ABC = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
+  let res = "amq.gen-";
+  for (let i = 0; i < 22; i++) {
+    res += ABC[Math.floor(Math.random() * ABC.length)];
   }
   return res;
 };
 
 const credentials = {
   plain: (username, password) => ({
-    mechanism: 'PLAIN',
-    response: () => '',
+    mechanism: "PLAIN",
+    response: () => "",
     username,
-    password
+    password,
   }),
   amqplain: (username, password) => ({
-    mechanism: 'AMQPLAIN',
-    response: () => '',
+    mechanism: "AMQPLAIN",
+    response: () => "",
     username,
-    password
+    password,
   }),
   external: () => ({
-    mechanism: 'EXTERNAL',
-    response: () => '',
-  })
-}
+    mechanism: "EXTERNAL",
+    response: () => "",
+  }),
+};
 
 module.exports = {
   connect: async () => ({
     createChannel,
     on: () => {},
-    close: () => {}
+    close: () => {},
   }),
-  credentials
+  credentials,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -53,9 +53,7 @@ const createDirectExchange = () => {
       });
     },
     getTargetQueues: (routingKey, options = {}) => {
-      const matchingBinding = bindings.find(
-        (binding) => binding.pattern === routingKey
-      );
+      const matchingBinding = bindings.find((binding) => binding.pattern === routingKey);
       return [matchingBinding.targetQueue];
     },
   };
@@ -72,13 +70,8 @@ const createHeadersExchange = () => {
       });
     },
     getTargetQueues: (routingKey, options = {}) => {
-      const isMatching = (binding, headers) =>
-        Object.keys(binding.options).every(
-          (key) => binding.options[key] === headers[key]
-        );
-      const matchingBinding = bindings.find((binding) =>
-        isMatching(binding, options.headers || {})
-      );
+      const isMatching = (binding, headers) => Object.keys(binding.options).every((key) => binding.options[key] === headers[key]);
+      const matchingBinding = bindings.find((binding) => isMatching(binding, options.headers || {}));
       return [matchingBinding.targetQueue];
     },
   };
@@ -109,14 +102,14 @@ const createChannel = async () => ({
     let exchange;
 
     switch (type) {
-      case "fanout":
+      case 'fanout':
         exchange = createFanoutExchange();
         break;
-      case "direct":
-      case "x-delayed-message":
+      case 'direct':
+      case 'x-delayed-message':
         exchange = createDirectExchange();
         break;
-      case "headers":
+      case 'headers':
         exchange = createHeadersExchange();
         break;
     }
@@ -147,7 +140,7 @@ const createChannel = async () => ({
     queues[queueName].add({
       content,
       fields: {
-        exchange: "",
+        exchange: '',
         routingKey: queueName,
       },
       properties: { headers: headers || {} },
@@ -176,8 +169,8 @@ const createChannel = async () => ({
 });
 
 const generateRandomQueueName = () => {
-  const ABC = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
-  let res = "amq.gen-";
+  const ABC = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_';
+  let res = 'amq.gen-';
   for (let i = 0; i < 22; i++) {
     res += ABC[Math.floor(Math.random() * ABC.length)];
   }
@@ -186,20 +179,20 @@ const generateRandomQueueName = () => {
 
 const credentials = {
   plain: (username, password) => ({
-    mechanism: "PLAIN",
-    response: () => "",
+    mechanism: 'PLAIN',
+    response: () => '',
     username,
     password,
   }),
   amqplain: (username, password) => ({
-    mechanism: "AMQPLAIN",
-    response: () => "",
+    mechanism: 'AMQPLAIN',
+    response: () => '',
     username,
     password,
   }),
   external: () => ({
-    mechanism: "EXTERNAL",
-    response: () => "",
+    mechanism: 'EXTERNAL',
+    response: () => '',
   }),
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ const createQueue = () => {
   let subscriber = null;
 
   return {
-    add: (item) => {
+    add: item => {
       if (subscriber) {
         subscriber(item);
       } else {
@@ -15,14 +15,14 @@ const createQueue = () => {
       }
     },
     get: () => messages.shift() || false,
-    addConsumer: (consumer) => {
-      messages.forEach((item) => consumer(item));
+    addConsumer: consumer => {
+      messages.forEach(item => consumer(item));
       messages = [];
       subscriber = consumer;
     },
     stopConsume: () => (subscriber = null),
     getMessageCount: () => messages.length,
-    purge: () => (messages = []),
+    purge: () => (messages = [])
   };
 };
 
@@ -33,12 +33,12 @@ const createFanoutExchange = () => {
       bindings.push({
         targetQueue: queueName,
         options,
-        pattern,
+        pattern
       });
     },
     getTargetQueues: (routingKey, options = {}) => {
-      return [...bindings.map((binding) => binding.targetQueue)];
-    },
+      return [...bindings.map(binding => binding.targetQueue)];
+    }
   };
 };
 
@@ -49,13 +49,13 @@ const createDirectExchange = () => {
       bindings.push({
         targetQueue: queueName,
         options,
-        pattern,
+        pattern
       });
     },
     getTargetQueues: (routingKey, options = {}) => {
-      const matchingBinding = bindings.find((binding) => binding.pattern === routingKey);
+      const matchingBinding = bindings.find(binding => binding.pattern === routingKey);
       return [matchingBinding.targetQueue];
-    },
+    }
   };
 };
 
@@ -66,14 +66,15 @@ const createHeadersExchange = () => {
       bindings.push({
         targetQueue: queueName,
         options,
-        pattern,
+        pattern
       });
     },
     getTargetQueues: (routingKey, options = {}) => {
-      const isMatching = (binding, headers) => Object.keys(binding.options).every((key) => binding.options[key] === headers[key]);
-      const matchingBinding = bindings.find((binding) => isMatching(binding, options.headers || {}));
+      const isMatching = (binding, headers) =>
+        Object.keys(binding.options).every(key => binding.options[key] === headers[key]);
+      const matchingBinding = bindings.find(binding => isMatching(binding, options.headers || {}));
       return [matchingBinding.targetQueue];
-    },
+    }
   };
 };
 
@@ -81,15 +82,15 @@ const createChannel = async () => ({
   on: (eventName, listener) => {
     eventListeners.push({ eventName, listener });
   },
-  emit: (emittedEventName) => {
+  emit: emittedEventName => {
     eventListeners.forEach(({ eventName, listener }) => {
       if (eventName === emittedEventName) {
         listener();
       }
-    });
+    })
   },
   close: () => {},
-  assertQueue: async (queueName) => {
+  assertQueue: async queueName => {
     if (!queueName) {
       queueName = generateRandomQueueName();
     }
@@ -101,7 +102,7 @@ const createChannel = async () => ({
   assertExchange: async (exchangeName, type) => {
     let exchange;
 
-    switch (type) {
+    switch(type) {
       case 'fanout':
         exchange = createFanoutExchange();
         break;
@@ -127,12 +128,12 @@ const createChannel = async () => ({
       content,
       fields: {
         exchange: exchangeName,
-        routingKey,
+        routingKey
       },
-      properties: options,
+      properties: options
     };
 
-    for (const queueName of queueNames) {
+    for(const queueName of queueNames) {
       queues[queueName].add(message);
     }
   },
@@ -141,9 +142,9 @@ const createChannel = async () => ({
       content,
       fields: {
         exchange: '',
-        routingKey: queueName,
+        routingKey: queueName
       },
-      properties: { headers: headers || {} },
+      properties: { headers: headers || {} }
     });
   },
   get: async (queueName, { noAck } = {}) => {
@@ -154,25 +155,25 @@ const createChannel = async () => ({
     queues[queueName].addConsumer(consumer);
     return { consumerTag: queueName };
   },
-  cancel: async (consumerTag) => queues[consumerTag].stopConsume(),
+  cancel: async consumerTag => queues[consumerTag].stopConsume(),
   ack: async () => {},
   nack: async (message, allUpTo = false, requeue = true) => {
     if (requeue) {
       queues[message.fields.routingKey].add(message);
     }
   },
-  checkQueue: (queueName) => ({
+  checkQueue: queueName => ({
     queue: queueName,
-    messageCount: queues[queueName].getMessageCount(),
+    messageCount: queues[queueName].getMessageCount()
   }),
-  purgeQueue: (queueName) => queues[queueName].purge(),
+  purgeQueue: queueName => queues[queueName].purge()
 });
 
 const generateRandomQueueName = () => {
   const ABC = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_';
   let res = 'amq.gen-';
-  for (let i = 0; i < 22; i++) {
-    res += ABC[Math.floor(Math.random() * ABC.length)];
+  for( let i=0; i<22; i++ ){
+    res += ABC[(Math.floor(Math.random() * ABC.length))];
   }
   return res;
 };
@@ -182,25 +183,25 @@ const credentials = {
     mechanism: 'PLAIN',
     response: () => '',
     username,
-    password,
+    password
   }),
   amqplain: (username, password) => ({
     mechanism: 'AMQPLAIN',
     response: () => '',
     username,
-    password,
+    password
   }),
   external: () => ({
     mechanism: 'EXTERNAL',
     response: () => '',
-  }),
-};
+  })
+}
 
 module.exports = {
   connect: async () => ({
     createChannel,
     on: () => {},
-    close: () => {},
+    close: () => {}
   }),
-  credentials,
+  credentials
 };

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -1,243 +1,292 @@
-const amqp = require('./main');
+const amqp = require("./main");
 
-test('getting a single message from queue', async () => {
-  const connection = await amqp.connect('some-random-uri');
+const generateQueueName = () => `test-queue-${Math.random()}`;
+
+test("getting a single message from queue", async () => {
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
-  await channel.assertQueue('test-queue', { durable: true });
+  const queueName = generateQueueName();
+  await channel.assertQueue(queueName, { durable: true });
 
-  await channel.sendToQueue('test-queue', 'test-content', {
-    headers: { groupBy: 'groupness' }
+  await channel.sendToQueue(queueName, "test-content", {
+    headers: { groupBy: "groupness" },
   });
 
-  const message = await channel.get('test-queue', { noAck: true });
-  const emptyQueueResponse = await channel.get('test-queue', { noAck: true });
+  const message = await channel.get(queueName, { noAck: true });
+  const emptyQueueResponse = await channel.get(queueName, { noAck: true });
 
   expect(message).toMatchObject({
-    content: 'test-content',
+    content: "test-content",
     properties: {
-      headers: { groupBy: 'groupness' }
-    }
+      headers: { groupBy: "groupness" },
+    },
   });
   expect(emptyQueueResponse).toEqual(false);
 });
 
-test('consuming messages', async () => {
-  const connection = await amqp.connect('some-random-uri');
+test("consuming messages", async () => {
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
-  await channel.assertQueue('test-queue', { durable: true });
+  const queueName = generateQueueName();
+  await channel.assertQueue(queueName, { durable: true });
   const consumer = jest.fn();
 
-  await channel.sendToQueue('test-queue', 'test-message-1');
+  await channel.sendToQueue(queueName, "test-message-1");
 
   await channel.prefetch(10);
-  const { consumerTag } = await channel.consume('test-queue', consumer);
+  const { consumerTag } = await channel.consume(queueName, consumer);
 
-  await channel.sendToQueue('test-queue', 'test-message-2');
+  await channel.sendToQueue(queueName, "test-message-2");
 
   await channel.cancel(consumerTag);
 
-  await channel.sendToQueue('test-queue', 'test-message-3');
+  await channel.sendToQueue(queueName, "test-message-3");
 
   expect(consumer.mock.calls).toMatchObject([
-    [{ content: 'test-message-1', properties: { headers: expect.anything() } }],
-    [{ content: 'test-message-2' }]
+    [{ content: "test-message-1", properties: { headers: expect.anything() } }],
+    [{ content: "test-message-2" }],
   ]);
 });
 
-test('nackinkg a message puts it back to queue', async () => {
-  const connection = await amqp.connect('some-random-uri');
+test("nackinkg a message puts it back to queue", async () => {
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
-  await channel.assertQueue('test-queue', { durable: true });
+  const queueName = generateQueueName();
+  await channel.assertQueue(queueName, { durable: true });
 
-  await channel.sendToQueue('test-queue', 'test-content');
+  await channel.sendToQueue(queueName, "test-content");
 
-  const message = await channel.get('test-queue');
-  const afterRead = await channel.get('test-queue');
+  const message = await channel.get(queueName);
+  const afterRead = await channel.get(queueName);
+  console.log("message", message);
+  console.log("afterRead", afterRead);
 
   await channel.nack(message);
 
-  const reRead = await channel.get('test-queue');
+  const reRead = await channel.get(queueName);
 
   expect(afterRead).toEqual(false);
-  expect(reRead.content).toEqual('test-content');
+  expect(reRead.content).toEqual("test-content");
 });
 
-test('checkQueue return status for the queue', async () => {
-  const connection = await amqp.connect('some-random-uri');
+test("checkQueue return status for the queue", async () => {
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
-  await channel.assertQueue('test-queue', { durable: true });
-  await channel.sendToQueue('test-queue', 'test-content-1');
-  await channel.sendToQueue('test-queue', 'test-content-2');
+  const queueName = generateQueueName();
+  await channel.assertQueue(queueName, { durable: true });
+  await channel.sendToQueue(queueName, "test-content-1");
+  await channel.sendToQueue(queueName, "test-content-2");
 
-  const status = await channel.checkQueue('test-queue');
+  const status = await channel.checkQueue(queueName);
 
   expect(status).toEqual({
-    queue: 'test-queue',
-    messageCount: 2
-  })
+    queue: queueName,
+    messageCount: 2,
+  });
 });
 
-test('purgeQueue deletes messages from queue', async () => {
-  const connection = await amqp.connect('some-random-uri');
+test("purgeQueue deletes messages from queue", async () => {
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
-  await channel.assertQueue('test-queue', { durable: true });
-  await channel.sendToQueue('test-queue', 'test-content-1');
-  await channel.sendToQueue('test-queue', 'test-content-2');
+  const queueName = generateQueueName();
+  await channel.assertQueue(queueName, { durable: true });
+  await channel.sendToQueue(queueName, "test-content-1");
+  await channel.sendToQueue(queueName, "test-content-2");
 
-  await channel.purgeQueue('test-queue');
+  await channel.purgeQueue(queueName);
 
-  const message = await channel.get('test-queue');
+  const message = await channel.get(queueName);
   expect(message).toEqual(false);
 });
 
-test('direct exchange', async () => {
-  const connection = await amqp.connect('some-random-uri');
+test("direct exchange", async () => {
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
+  await channel.assertExchange("retry-exchange", "direct");
+  await channel.assertQueue("retry-queue-10s");
+  await channel.assertQueue("retry-queue-20s");
+  await channel.bindQueue(
+    "retry-queue-10s",
+    "retry-exchange",
+    "some-target-queue"
+  );
+  await channel.bindQueue(
+    "retry-queue-20s",
+    "retry-exchange",
+    "some-other-queue"
+  );
 
-  await channel.assertExchange('retry-exchange', 'direct');
-  await channel.assertQueue('retry-queue-10s');
-  await channel.assertQueue('retry-queue-20s');
-  await channel.bindQueue('retry-queue-10s', 'retry-exchange', 'some-target-queue');
-  await channel.bindQueue('retry-queue-20s', 'retry-exchange', 'some-other-queue');
+  await channel.publish("retry-exchange", "some-target-queue", "content-1");
 
-  await channel.publish('retry-exchange', 'some-target-queue', 'content-1')
-
-  expect(await channel.get('retry-queue-10s')).toMatchObject({
-    content: 'content-1',
+  expect(await channel.get("retry-queue-10s")).toMatchObject({
+    content: "content-1",
     fields: {
-      exchange: 'retry-exchange',
-      routingKey: 'some-target-queue'
-    }
+      exchange: "retry-exchange",
+      routingKey: "some-target-queue",
+    },
   });
-  expect(await channel.get('retry-queue-20s')).toEqual(false);
+  expect(await channel.get("retry-queue-20s")).toEqual(false);
 });
 
-test('x-delayed-message exchange', async () => {
-  const connection = await amqp.connect('some-random-uri');
+test("x-delayed-message exchange", async () => {
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
+  const queueName = generateQueueName();
+  await channel.assertExchange("retry-exchange", "x-delayed-message");
+  await channel.assertQueue("retry-queue-10s");
+  await channel.assertQueue("retry-queue-20s");
+  await channel.bindQueue(
+    "retry-queue-10s",
+    "retry-exchange",
+    "some-target-queue"
+  );
+  await channel.bindQueue(
+    "retry-queue-20s",
+    "retry-exchange",
+    "some-other-queue"
+  );
 
-  await channel.assertExchange('retry-exchange', 'x-delayed-message');
-  await channel.assertQueue('retry-queue-10s');
-  await channel.assertQueue('retry-queue-20s');
-  await channel.bindQueue('retry-queue-10s', 'retry-exchange', 'some-target-queue');
-  await channel.bindQueue('retry-queue-20s', 'retry-exchange', 'some-other-queue');
+  await channel.publish("retry-exchange", "some-target-queue", "content-1");
 
-  await channel.publish('retry-exchange', 'some-target-queue', 'content-1')
-
-  expect(await channel.get('retry-queue-10s')).toMatchObject({
-    content: 'content-1',
+  expect(await channel.get("retry-queue-10s")).toMatchObject({
+    content: "content-1",
     fields: {
-      exchange: 'retry-exchange',
-      routingKey: 'some-target-queue'
+      exchange: "retry-exchange",
+      routingKey: "some-target-queue",
+    },
+  });
+  expect(await channel.get("retry-queue-20s")).toEqual(false);
+
+  await channel.assertExchange(
+    "retry-exchange-with-options",
+    "x-delayed-message",
+    {
+      durable: true,
+      arguments: { "x-delayed-type": "direct" },
     }
-  });
-  expect(await channel.get('retry-queue-20s')).toEqual(false);
+  );
+  await channel.assertQueue("retry-queue-10s-options");
+  await channel.assertQueue("retry-queue-20s-options");
+  await channel.bindQueue(
+    "retry-queue-10s-options",
+    "retry-exchange-with-options",
+    "some-target-queue-options"
+  );
+  await channel.bindQueue(
+    "retry-queue-20s-options",
+    "retry-exchange-with-options",
+    "some-other-queue-options"
+  );
 
-  await channel.assertExchange('retry-exchange-with-options', 'x-delayed-message', {
-    durable: true,
-    arguments: { 'x-delayed-type': 'direct' },
-  });
-  await channel.assertQueue('retry-queue-10s-options');
-  await channel.assertQueue('retry-queue-20s-options');
-  await channel.bindQueue('retry-queue-10s-options', 'retry-exchange-with-options', 'some-target-queue-options');
-  await channel.bindQueue('retry-queue-20s-options', 'retry-exchange-with-options', 'some-other-queue-options');
+  await channel.publish(
+    "retry-exchange-with-options",
+    "some-target-queue-options",
+    "content-2"
+  );
 
-  await channel.publish('retry-exchange-with-options', 'some-target-queue-options', 'content-2')
-
-  expect(await channel.get('retry-queue-10s-options')).toMatchObject({
-    content: 'content-2',
+  expect(await channel.get("retry-queue-10s-options")).toMatchObject({
+    content: "content-2",
     fields: {
-      exchange: 'retry-exchange-with-options',
-      routingKey: 'some-target-queue-options'
-    }
+      exchange: "retry-exchange-with-options",
+      routingKey: "some-target-queue-options",
+    },
   });
-  expect(await channel.get('retry-queue-20s-options')).toEqual(false);
+  expect(await channel.get("retry-queue-20s-options")).toEqual(false);
 });
 
-test('headers exchange', async () => {
-  const connection = await amqp.connect('some-random-uri');
+test("headers exchange", async () => {
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
 
-  await channel.assertExchange('retry-exchange', 'headers');
-  await channel.assertQueue('retry-queue-10s');
-  await channel.assertQueue('retry-queue-20s');
-  await channel.bindQueue('retry-queue-10s', 'retry-exchange', '', { retryCount: 1 });
-  await channel.bindQueue('retry-queue-20s', 'retry-exchange', '', { retryCount: 2 });
-
-  await channel.publish('retry-exchange', 'some-target-queue', 'content-1', {
-    headers: { retryCount: 1 }
+  await channel.assertExchange("retry-exchange", "headers");
+  await channel.assertQueue("retry-queue-10s");
+  await channel.assertQueue("retry-queue-20s");
+  await channel.bindQueue("retry-queue-10s", "retry-exchange", "", {
+    retryCount: 1,
   });
-  await channel.publish('retry-exchange', 'some-other-queue', 'content-2', {
-    headers: { retryCount: 2 }
+  await channel.bindQueue("retry-queue-20s", "retry-exchange", "", {
+    retryCount: 2,
   });
 
-  expect(await channel.get('retry-queue-10s')).toMatchObject({
-    content: 'content-1',
+  await channel.publish("retry-exchange", "some-target-queue", "content-1", {
+    headers: { retryCount: 1 },
+  });
+  await channel.publish("retry-exchange", "some-other-queue", "content-2", {
+    headers: { retryCount: 2 },
+  });
+
+  expect(await channel.get("retry-queue-10s")).toMatchObject({
+    content: "content-1",
     fields: {
-      exchange: 'retry-exchange',
-      routingKey: 'some-target-queue'
-    }
+      exchange: "retry-exchange",
+      routingKey: "some-target-queue",
+    },
   });
-  expect(await channel.get('retry-queue-20s')).toMatchObject({ content: 'content-2'});
+  expect(await channel.get("retry-queue-20s")).toMatchObject({
+    content: "content-2",
+  });
 });
 
-test('emitting on a channel triggers on callbacks', async () => {
-  const connection = await amqp.connect('some-random-uri');
+test("emitting on a channel triggers on callbacks", async () => {
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
   const listener = jest.fn();
 
-  channel.on('close', listener);
-  channel.emit('close');
+  channel.on("close", listener);
+  channel.emit("close");
 
   expect(listener).toBeCalled();
 });
 
-test('it should always set header property of messages even if not set', async () => {
-  const connection = await amqp.connect('some-random-uri');
+test("it should always set header property of messages even if not set", async () => {
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
-  await channel.assertQueue('test-queue');
+  const queueName = generateQueueName();
+  await channel.assertQueue(queueName);
 
-  await channel.sendToQueue('test-queue', 'test-content');
+  await channel.sendToQueue(queueName, "test-content");
 
-  const message = await channel.get('test-queue');
+  const message = await channel.get(queueName);
 
   expect(message).toMatchObject({
-    content: 'test-content',
+    content: "test-content",
     properties: {
-      headers: expect.anything()
-    }
+      headers: expect.anything(),
+    },
   });
 });
 
-it('should not put nack-ed messages back to queue if requeue is set to false', async () => {
-  const connection = await amqp.connect('some-random-uri');
+it("should not put nack-ed messages back to queue if requeue is set to false", async () => {
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
-  await channel.assertQueue('test-queue');
+  const queueName = generateQueueName();
+  await channel.assertQueue(queueName);
 
-  await channel.sendToQueue('test-queue', 'test-content');
+  await channel.sendToQueue(queueName, "test-content");
 
-  const message = await channel.get('test-queue');
+  const message = await channel.get(queueName);
   await channel.nack(message, false, false);
 
-  const reRead = await channel.get('test-queue');
+  const reRead = await channel.get(queueName);
 
   expect(reRead).toEqual(false);
 });
 
 test('assert queue should return object with property "queue"', async () => {
-  const connection = await amqp.connect('some-random-uri');
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
-  const queue = await channel.assertQueue('test-queue');
+  const queueName = generateQueueName();
+  const queue = await channel.assertQueue(queueName);
   expect(queue).toMatchObject({
-    queue: 'test-queue'
+    queue: queueName,
   });
 });
 
 test('assert empty queue should create new queue with random name with prefix "amq.gen-"', async () => {
-  const connection = await amqp.connect('some-random-uri');
+  const connection = await amqp.connect("some-random-uri");
   const channel = await connection.createChannel();
-  const queue1 = await channel.assertQueue('');
-  const queue2 = await channel.assertQueue('');
+  const queue1 = await channel.assertQueue("");
+  const queue2 = await channel.assertQueue("");
 
   expect(queue1.queue).toMatch(/^amq.gen-\w{22}/);
   expect(queue2.queue).toMatch(/^amq.gen-\w{22}/);
@@ -252,22 +301,48 @@ test('assert "credentials" to have been defined with required methods', () => {
 });
 
 test('assert required methods of "credentials"', () => {
-  expect(amqp.credentials.plain('user', 'pass')).toEqual({
-    mechanism: 'PLAIN',
+  expect(amqp.credentials.plain("user", "pass")).toEqual({
+    mechanism: "PLAIN",
     response: expect.any(Function),
-    username: 'user',
-    password: 'pass',
+    username: "user",
+    password: "pass",
   });
 
-  expect(amqp.credentials.amqplain('user', 'pass')).toEqual({
-    mechanism: 'AMQPLAIN',
+  expect(amqp.credentials.amqplain("user", "pass")).toEqual({
+    mechanism: "AMQPLAIN",
     response: expect.any(Function),
-    username: 'user',
-    password: 'pass',
+    username: "user",
+    password: "pass",
   });
 
   expect(amqp.credentials.external()).toEqual({
-    mechanism: 'EXTERNAL',
-    response: expect.any(Function)
+    mechanism: "EXTERNAL",
+    response: expect.any(Function),
   });
+});
+
+test("ensure consuming messages works", async () => {
+  const connection = await amqp.connect("some-random-uri");
+  const channel = await connection.createChannel();
+  const queueName = generateQueueName();
+  await channel.assertQueue(queueName);
+  let firstMessagePayload = null;
+  let secondMessagePayload = null;
+  await channel.consume(queueName, ({ content }) => {
+    switch (content) {
+      case 1:
+        firstMessagePayload = 1;
+        break;
+      case 2:
+        secondMessagePayload = 2;
+        break;
+    }
+  });
+
+  await channel.assertQueue(queueName);
+  await channel.sendToQueue(queueName, 1);
+  await channel.assertQueue(queueName);
+  await channel.sendToQueue(queueName, 2);
+  expect(firstMessagePayload).toBe(1);
+  expect(secondMessagePayload).toBe(2);
 });


### PR DESCRIPTION
Currently, every time a queue is asserted to a channel by calling the `channel.assertQueue` function, a new queue gets created and overwrites the old queue with the same name. This means that all subscribers are wiped out and will not receive any messages sent to the queue via the `channel.sendToQueue` function. This PR changes it so that when a queue is asserted to an exchange, the existing queue is used (if it exists).

I've also added a test that covers this case. 

There were a few false positive test cases existing here that started failing once a made this change. To fix this, I had to change a few existing tests to initiate a new queue using a unique `queueName` via the `generateQueueName` function for each test. I think this makes more sense from a test standpoint to isolate an individual test's surface area anyway. 

Happy to discuss more as well, thanks for putting this library together!