### PR TITLE
Use native nodejs EventEmitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/main.js",
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch --silent=false"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-amqplib",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "stub rabbit mq in integration tests",
   "main": "src/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-amqplib",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "stub rabbit mq in integration tests",
   "main": "src/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/main.js",
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watch --silent=false"
+    "test:watch": "jest --watch"
   },
   "repository": {
     "type": "git",

--- a/src/main.js
+++ b/src/main.js
@@ -7,9 +7,9 @@ const createQueue = () => {
   let subscriber = null;
 
   return {
-    add: item => {
+    add: async item => {
       if (subscriber) {
-        subscriber(item);
+        await subscriber(item);
       } else {
         messages.push(item);
       }
@@ -138,7 +138,7 @@ const createChannel = async () => ({
     }
   },
   sendToQueue: async (queueName, content, { headers } = {}) => {
-    queues[queueName].add({
+    await queues[queueName].add({
       content,
       fields: {
         exchange: '',

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
+const EventEmitter = require('events')
+
 const queues = {};
 const exchanges = {};
-const eventListeners = [];
 
 const createQueue = () => {
   let messages = [];
@@ -79,16 +80,7 @@ const createHeadersExchange = () => {
 };
 
 const createChannel = async () => ({
-  on: (eventName, listener) => {
-    eventListeners.push({ eventName, listener });
-  },
-  emit: emittedEventName => {
-    eventListeners.forEach(({ eventName, listener }) => {
-      if (eventName === emittedEventName) {
-        listener();
-      }
-    })
-  },
+  ...EventEmitter.prototype,
   close: () => {},
   assertQueue: async queueName => {
     if (!queueName) {
@@ -199,9 +191,12 @@ const credentials = {
 
 module.exports = {
   connect: async () => ({
+    ...EventEmitter.prototype,
     createChannel,
-    on: () => {},
-    close: () => {}
+    isConnected: true,
+    close: function () {
+      this.emit('close')
+    }
   }),
   credentials
 };

--- a/src/main.js
+++ b/src/main.js
@@ -54,6 +54,7 @@ const createDirectExchange = () => {
       });
     },
     getTargetQueues: (routingKey, options = {}) => {
+      if (routingKey === "#") return bindings.map(binding => binding.targetQueue)
       const matchingBinding = bindings.find(binding => binding.pattern === routingKey);
       return [matchingBinding.targetQueue];
     }

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -1,8 +1,6 @@
 const amqp = require('./main');
 
 const generateQueueName = () => `test-queue-${Math.random()}`;
-const generateExchangeName = () => `test-exchange-${Math.random()}`;
-const generateRoutingKey = () => `test-routing-key-${Math.random()}`;
 
 test('getting a single message from queue', async () => {
   const connection = await amqp.connect('some-random-uri');

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -312,3 +312,32 @@ test('ensure consuming messages works even is queues is asserted multiple times'
 
   expect(receivedMessages).toEqual([1, 2]);
 });
+
+test('promise race condition for publishing to another queue from consumer', async () => {
+
+  const connection = await amqp.connect('some-random-uri');
+  const channel = await connection.createChannel();
+
+  const queueName = generateQueueName();
+  const errorQueueName = generateQueueName()
+
+  const listener = jest.fn().mockResolvedValue(true);
+
+  const cb = async () => {
+    await listener()
+    await channel.assertQueue(errorQueueName);
+    await channel.sendToQueue(errorQueueName)
+  }
+
+  await channel.assertQueue(queueName)
+  await channel.consume(queueName, cb);
+
+  await channel.assertQueue(errorQueueName)
+  await channel.consume(errorQueueName, listener);
+
+
+
+  await channel.sendToQueue(queueName, 2);
+
+  expect(listener).toBeCalledTimes(2);
+});

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -1,6 +1,8 @@
 const amqp = require('./main');
 
 const generateQueueName = () => `test-queue-${Math.random()}`;
+const generateExchangeName = () => `test-exchange-${Math.random()}`;
+const generateRoutingKey = () => `test-routing-key-${Math.random()}`;
 
 test('getting a single message from queue', async () => {
   const connection = await amqp.connect('some-random-uri');
@@ -311,4 +313,14 @@ test('ensure consuming messages works even is queues is asserted multiple times'
   await channel.sendToQueue(queueName, 2);
 
   expect(receivedMessages).toEqual([1, 2]);
+});
+
+test('emitting on a connection triggers on callbacks', async () => {
+  const connection = await amqp.connect('some-random-uri');
+  const listener = jest.fn();
+
+  connection.on('error', listener);
+  connection.emit('error');
+
+  expect(listener).toBeCalled();
 });


### PR DESCRIPTION
This PR adds the [native node.js EventEmitter](https://nodejs.org/api/events.html) to `Connection` object and changes the `Channel` prototypes to use the EventEmitter instead of custom implementation. This brings this mocking package closer in-line to amqplib package which also uses the nodejs EventEmitter module.

I'm interested in providing a more complete `Connection.close` function that would mimic the amqplib nodejs package. The current implementation just emits a `close` event. I'd have to think a bit more on how we could get the close functionality to mimic the actual package.

One idea I had was having the `Connection` store some internal state such about the status of the connection, and throw an error if a consumer attempts to operator on a `Channel` in which the `Connection` is closed. 