### PR TITLE
Add ConfirmChannel and "direct" exchange support 

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 const EventEmitter = require('events')
+const util = require('util');
 
 const queues = {};
 const exchanges = {};
@@ -161,6 +162,16 @@ const createChannel = async () => ({
   purgeQueue: queueName => queues[queueName].purge()
 });
 
+const createConfirmChannel = async () => {
+  const basis = await createChannel();
+  return {
+    ...basis,
+    publish: util.callbackify(basis.publish),
+    sendToQueue: util.callbackify(basis.sendToQueue),
+    waitForConfirms: async () => {}
+  };
+};
+
 const generateRandomQueueName = () => {
   const ABC = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_';
   let res = 'amq.gen-';
@@ -193,6 +204,7 @@ module.exports = {
   connect: async () => ({
     ...EventEmitter.prototype,
     createChannel,
+    createConfirmChannel,
     isConnected: true,
     close: function () {
       this.emit('close')

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,7 @@
 const EventEmitter = require('events')
 const util = require('util');
 
-const queues = {};
-const exchanges = {};
+const DEFAULT_EXCHANGE_NAME = '';
 
 const createQueue = () => {
   let messages = [];
@@ -80,6 +79,11 @@ const createHeadersExchange = () => {
   };
 };
 
+const queues = {};
+const exchanges = {
+  [DEFAULT_EXCHANGE_NAME]: createDirectExchange()
+};
+
 const createChannel = async () => ({
   ...EventEmitter.prototype,
   close: () => {},
@@ -89,6 +93,8 @@ const createChannel = async () => ({
     }
     if (!(queueName in queues)) {
       queues[queueName] = createQueue();
+      const exchange = exchanges[DEFAULT_EXCHANGE_NAME];
+      exchange.bindQueue(queueName, queueName);
     }
     return { queue: queueName };
   },


### PR DESCRIPTION
1. Make possible to create ConfirmChannel. See [docs](https://amqp-node.github.io/amqplib/channel_api.html#confirmchannel).
2. Add support of "default" exchanges (like pushing directly to queue). See [docs](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default).