### PR TITLE
Feature: add expiration (TTL) and dead letter (DLX) logic

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -210,7 +210,7 @@ const deadLetterProceed = (channel, message, reason, perMessageTtl = false) => {
 
   msg.properties.headers['x-death'].unshift(dlEntry);
 
-  channel.publish(dlExchange, dlRoutingKey, msg.content, msg.properties);
+  channel.publish(dlExchange, dlRoutingKey, msg.content, msg.properties, () => {});
 };
 
 const createChannel = async () => ({
@@ -271,8 +271,8 @@ const createChannel = async () => ({
     }
     return true;
   },
-  sendToQueue: async function (queueName, content, options = { headers: {} }) {
-    return this.publish(DEFAULT_EXCHANGE_NAME, queueName, content, options);
+  sendToQueue: async function (queueName, content, options = { headers: {} }, cb = () => {}) {
+    return this.publish(DEFAULT_EXCHANGE_NAME, queueName, content, options, cb);
   },
   get: async (queueName, { noAck } = {}) => {
     return queues[queueName].get();

--- a/src/main.js
+++ b/src/main.js
@@ -193,14 +193,14 @@ const deadLetterProceed = (channel, message, reason, perMessageTtl = false) => {
   }
 
   const dlEntry = {
+    count: msg.properties.headers['x-death'].filter(
+        v => v.queue === queueName && v.reason === reason
+    ).length + 1,
+    exchange: msg.fields.exchange,
     queue: queueName,
     reason,
-    time: Date.now(),
-    exchange: msg.fields.exchange,
-    'routing-keys': msg.fields.routingKey,
-    count: msg.properties.headers['x-death'].filter(
-      v => v.queue === queueName && v.reason === reason
-    ).length,
+    'routing-keys': [msg.fields.routingKey],
+    time: { '!': 'timestamp', value: Date.now() / 1000 },
   };
 
   if (reason === 'expired' && perMessageTtl) {

--- a/src/main.js
+++ b/src/main.js
@@ -288,15 +288,15 @@ const createChannel = async () => ({
     return { consumerTag: queueName };
   },
   cancel: async consumerTag => queues[consumerTag].stopConsume(),
-  ack: async () => {},
-  nack: async function (message, allUpTo = false, requeue = true) {
+  ack: () => {},
+  nack: function (message, allUpTo = false, requeue = true) {
     if (requeue) {
       queues[message[queueNameSymbol]].add(message);
     } else {
       deadLetterProceed(this, message, 'rejected');
     }
   },
-  checkQueue: queueName => ({
+  checkQueue: async queueName => ({
     queue: queueName,
     messageCount: queues[queueName].getMessageCount()
   }),

--- a/src/main.js
+++ b/src/main.js
@@ -253,7 +253,7 @@ const createChannel = async () => ({
     const exchange = exchanges[sourceExchange];
     exchange.bindQueue(queue, pattern, options);
   },
-  publish: async (exchangeName, routingKey, content, options = {}) => {
+  publish: (exchangeName, routingKey, content, options = {}) => {
     const exchange = exchanges[exchangeName];
     const queueNames = exchange.getTargetQueues(routingKey, options);
     const message = {
@@ -271,8 +271,8 @@ const createChannel = async () => ({
     }
     return true;
   },
-  sendToQueue: async function (queueName, content, options = { headers: {} }, cb = () => {}) {
-    return this.publish(DEFAULT_EXCHANGE_NAME, queueName, content, options, cb);
+  sendToQueue: function (queueName, content, options = { headers: {} }) {
+    return this.publish(DEFAULT_EXCHANGE_NAME, queueName, content, options);
   },
   get: async (queueName, { noAck } = {}) => {
     return queues[queueName].get();

--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,7 @@ const createQueue = options => {
     },
     stopConsume: () => (subscriber = null),
     getMessageCount: () => messages.length,
+    getConsumerCount: () => subscriber ? 1 : 0,
     purge: () => (messages = []),
     getDeadLetterInfo: () => {
       if (options && options.arguments) {
@@ -270,7 +271,11 @@ const createChannel = async () => ({
       const exchange = exchanges[DEFAULT_EXCHANGE_NAME];
       exchange.bindQueue(queueName, queueName);
     }
-    return { queue: queueName };
+    return {
+      queue: queueName,
+      messageCount: queues[queueName].getMessageCount(),
+      consumerCount: queues[queueName].getConsumerCount(),
+    };
   },
   assertExchange: async (exchangeName, type, options = {}) => {
     let exchange;
@@ -327,7 +332,8 @@ const createChannel = async () => ({
   },
   checkQueue: async queueName => ({
     queue: queueName,
-    messageCount: queues[queueName].getMessageCount()
+    messageCount: queues[queueName].getMessageCount(),
+    consumerCount: queues[queueName].getConsumerCount(),
   }),
   checkExchange: async exchangeName => ({
     exchange: exchangeName,

--- a/src/main.js
+++ b/src/main.js
@@ -83,7 +83,7 @@ const createFanoutExchange = () => {
       });
     },
     getTargetQueues: (routingKey, options = {}) => {
-      return [...bindings.map(binding => binding.targetQueue)];
+      return bindings.map(b => b.targetQueue);
     }
   };
 };
@@ -98,10 +98,8 @@ const createDirectExchange = () => {
         pattern
       });
     },
-    getTargetQueues: (routingKey, options = {}) => {
-      const matchingBinding = bindings.find(binding => binding.pattern === routingKey);
-      return [matchingBinding.targetQueue];
-    }
+    getTargetQueues: (routingKey, options = {}) =>
+      bindings.filter(b => b.pattern === routingKey).map(b => b.targetQueue)
   };
 };
 
@@ -143,10 +141,8 @@ const createTopicExchange = () => {
         patternRegexp: maskToRegexp(pattern)
       });
     },
-    getTargetQueues: (routingKey, options = {}) => {
-      const matchingBinding = bindings.filter(binding => binding.patternRegexp.test(routingKey));
-      return matchingBinding.map(b => b.targetQueue);
-    }
+    getTargetQueues: (routingKey, options = {}) =>
+      bindings.filter(b => b.patternRegexp.test(routingKey)).map(b => b.targetQueue)
   };
 };
 
@@ -161,10 +157,9 @@ const createHeadersExchange = () => {
       });
     },
     getTargetQueues: (routingKey, options = {}) => {
-      const isMatching = (binding, headers) =>
+      const isMatching = (binding, headers = {}) =>
         Object.keys(binding.options).every(key => binding.options[key] === headers[key]);
-      const matchingBinding = bindings.find(binding => isMatching(binding, options.headers || {}));
-      return [matchingBinding.targetQueue];
+      return bindings.filter(b => isMatching(b, options.headers)).map(b => b.targetQueue);
     }
   };
 };

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -60,7 +60,7 @@ test('nackinkg a message puts it back to queue', async () => {
   const message = await channel.get(queueName);
   const afterRead = await channel.get(queueName);
 
-  await channel.nack(message);
+  channel.nack(message);
 
   const reRead = await channel.get(queueName);
 
@@ -374,7 +374,7 @@ it('should not put nack-ed messages back to queue if requeue is set to false', a
   await channel.sendToQueue(queueName, 'test-content');
 
   const message = await channel.get(queueName);
-  await channel.nack(message, false, false);
+  channel.nack(message, false, false);
 
   const reRead = await channel.get(queueName);
 

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -12,7 +12,7 @@ test('getting a single message from queue', async () => {
   const queueName = generateQueueName();
   await channel.assertQueue(queueName, { durable: true });
 
-  await channel.sendToQueue(queueName, 'test-content', {
+  channel.sendToQueue(queueName, 'test-content', {
     headers: { groupBy: 'groupness' }
   });
 
@@ -35,16 +35,16 @@ test('consuming messages', async () => {
   await channel.assertQueue(queueName, { durable: true });
   const consumer = jest.fn();
 
-  await channel.sendToQueue(queueName, 'test-message-1');
+  channel.sendToQueue(queueName, 'test-message-1');
 
   await channel.prefetch(10);
   const { consumerTag } = await channel.consume(queueName, consumer);
 
-  await channel.sendToQueue(queueName, 'test-message-2');
+  channel.sendToQueue(queueName, 'test-message-2');
 
   await channel.cancel(consumerTag);
 
-  await channel.sendToQueue(queueName, 'test-message-3');
+  channel.sendToQueue(queueName, 'test-message-3');
 
   expect(consumer.mock.calls).toMatchObject([
     [{ content: 'test-message-1', properties: { headers: expect.anything() } }],
@@ -58,7 +58,7 @@ test('nackinkg a message puts it back to queue', async () => {
   const queueName = generateQueueName();
   await channel.assertQueue(queueName, { durable: true });
 
-  await channel.sendToQueue(queueName, 'test-content');
+  channel.sendToQueue(queueName, 'test-content');
 
   const message = await channel.get(queueName);
   const afterRead = await channel.get(queueName);
@@ -76,8 +76,8 @@ test('checkQueue return status for the queue', async () => {
   const channel = await connection.createChannel();
   const queueName = generateQueueName();
   await channel.assertQueue(queueName, { durable: true });
-  await channel.sendToQueue(queueName, 'test-content-1');
-  await channel.sendToQueue(queueName, 'test-content-2');
+  channel.sendToQueue(queueName, 'test-content-1');
+  channel.sendToQueue(queueName, 'test-content-2');
 
   const status = await channel.checkQueue(queueName);
 
@@ -104,8 +104,8 @@ test('purgeQueue deletes messages from queue', async () => {
   const channel = await connection.createChannel();
   const queueName = generateQueueName();
   await channel.assertQueue(queueName, { durable: true });
-  await channel.sendToQueue(queueName, 'test-content-1');
-  await channel.sendToQueue(queueName, 'test-content-2');
+  channel.sendToQueue(queueName, 'test-content-1');
+  channel.sendToQueue(queueName, 'test-content-2');
 
   await channel.purgeQueue(queueName);
 
@@ -359,7 +359,7 @@ test('it should always set header property of messages even if not set', async (
   const queueName = generateQueueName();
   await channel.assertQueue(queueName);
 
-  await channel.sendToQueue(queueName, 'test-content');
+  channel.sendToQueue(queueName, 'test-content');
 
   const message = await channel.get(queueName);
 
@@ -377,7 +377,7 @@ it('should not put nack-ed messages back to queue if requeue is set to false', a
   const queueName = generateQueueName();
   await channel.assertQueue(queueName);
 
-  await channel.sendToQueue(queueName, 'test-content');
+  channel.sendToQueue(queueName, 'test-content');
 
   const message = await channel.get(queueName);
   channel.nack(message, false, false);
@@ -447,9 +447,9 @@ test('ensure consuming messages works even is queues is asserted multiple times'
   });
 
   await channel.assertQueue(queueName);
-  await channel.sendToQueue(queueName, 1);
+  channel.sendToQueue(queueName, 1);
   await channel.assertQueue(queueName);
-  await channel.sendToQueue(queueName, 2);
+  channel.sendToQueue(queueName, 2);
 
   expect(receivedMessages).toEqual([1, 2]);
 });
@@ -465,7 +465,7 @@ test('promise race condition for publishing to another queue from consumer', asy
 
   const cb = async () => {
     await listener();
-    await channel.sendToQueue(errorQueueName);
+    channel.sendToQueue(errorQueueName);
   }
 
   await channel.assertQueue(queueName);
@@ -474,8 +474,9 @@ test('promise race condition for publishing to another queue from consumer', asy
   await channel.consume(queueName, cb);
   await channel.consume(errorQueueName, listener);
 
-  await channel.sendToQueue(queueName, 2);
+  channel.sendToQueue(queueName, 2);
 
+  await sleep(0);
   expect(listener).toBeCalledTimes(2);
 });
 
@@ -511,7 +512,7 @@ test.each(ttlCases)(`should receive=$result message when message TTL=$msgTtl and
   const publishOptions = test.msgTtl >= 0 ? {
     expiration: test.msgTtl,
   } : undefined;
-  await channel.sendToQueue(queueName, 'test-content', publishOptions);
+  channel.sendToQueue(queueName, 'test-content', publishOptions);
   await sleep(test.wait);
 
   const message = await channel.get(queueName);
@@ -547,7 +548,7 @@ test.each(dlxCases)('should route message with TTL=$msgTtl to queue ' +
   const publishOptions = test.msgTtl >= 0 ? {
     expiration: test.msgTtl,
   } : undefined;
-  await channel.sendToQueue(queues[0], 'test-content', publishOptions);
+  channel.sendToQueue(queues[0], 'test-content', publishOptions);
   await sleep(test.wait);
 
   for (let i = 0; i < queues.length; i++) {
@@ -574,7 +575,7 @@ test('should route to DLX after nack (requeue=false)', async () => {
   });
   await channel.assertQueue(targetQueue);
   await channel.bindQueue(targetQueue, exchange, routingKey);
-  await channel.sendToQueue(nackQueue, 'test-content');
+  channel.sendToQueue(nackQueue, 'test-content');
 
   const message = await channel.get(nackQueue);
   expect(message).toBeTruthy();

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -592,11 +592,11 @@ test('should route to DLX after nack (requeue=false)', async () => {
         'x-first-death-queue': nackQueue,
         'x-first-death-reason': 'rejected',
         'x-death': [{
-          count: 0,
+          count: 1,
           exchange: '',
           queue: nackQueue,
           reason: 'rejected',
-          'routing-keys': nackQueue,
+          'routing-keys': [nackQueue],
         }]
       },
     },


### PR DESCRIPTION
See docs [here](https://www.rabbitmq.com/ttl.html) and [here](https://www.rabbitmq.com/dlx.html).
Also added [`on('return')`](https://amqp-node.github.io/amqplib/channel_api.html#channel_events) and [`alternateExchange`](https://amqp-node.github.io/amqplib/channel_api.html#channel_assertExchange) logic, so fixes #30 