### PR TITLE
fix: required message headers property

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -186,7 +186,10 @@ const publishMessage = (exchangeName, routingKey, content, options) => {
       exchange: exchangeName,
       routingKey
     },
-    properties: options
+    properties: {
+      headers: {},
+      ...options
+    }
   };
 
   if (!queueNames.length) {


### PR DESCRIPTION
Property `headers` is required in `message.properties`, and lack of it will throw error in runtime. We can use default value (`{}`) for it.

See [types link](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ae199c4d1ac55cbc848449934d3cc59bc3ea9918/types/amqplib/properties.d.ts#L179).